### PR TITLE
Add Uniswap Wallet and Rainbow to ecosystem wallets

### DIFF
--- a/docs/pages/ecosystem.mdx
+++ b/docs/pages/ecosystem.mdx
@@ -20,9 +20,11 @@
 
 - [Ambire](https://www.ambire.com)
 - [MetaMask](https://metamask.io)
-- [Trust Wallet](https://trustwallet.com)
-- [TokenPocket](https://tokenpocket.pro)
 - [PillarX](https://pillarx.app)
+- [Rainbow](https://rainbow.me)
+- [TokenPocket](https://tokenpocket.pro)
+- [Trust Wallet](https://trustwallet.com)
+- [Uniswap Wallet](https://wallet.uniswap.org)
 
 ## Apps
 

--- a/docs/pages/ecosystem.mdx
+++ b/docs/pages/ecosystem.mdx
@@ -20,10 +20,10 @@
 
 - [Ambire](https://www.ambire.com)
 - [MetaMask](https://metamask.io)
-- [PillarX](https://pillarx.app)
-- [Rainbow](https://rainbow.me)
-- [TokenPocket](https://tokenpocket.pro)
 - [Trust Wallet](https://trustwallet.com)
+- [TokenPocket](https://tokenpocket.pro)
+- [PillarX](https://pillarx.app)
+- [Rainbow Wallet](https://rainbow.me)
 - [Uniswap Wallet](https://wallet.uniswap.org)
 
 ## Apps

--- a/docs/pages/ecosystem.mdx
+++ b/docs/pages/ecosystem.mdx
@@ -15,6 +15,7 @@
 - [Rhinestone](https://docs.rhinestone.dev)
 - [Etherspot](https://etherspot.io)
 - [Curvegrid's EIP-7702 Delegation Checker](https://eip7702.app)
+- [Calibur](https://github.com/uniswap/calibur)
 
 ## Wallets
 

--- a/docs/pages/reference.mdx
+++ b/docs/pages/reference.mdx
@@ -5,6 +5,11 @@
 - Proxy pattern: https://gist.github.com/lightclient/7742e84fde4962f32928c6177eda7523
 - Best practices: https://hackmd.io/@rimeissner/eip7702-best-practices
 
+## Interfaces
+
+- EIP-4337 UserOperation: https://eips.ethereum.org/EIPS/eip-4337
+- ERC-7821 Execute: https://eips.ethereum.org/EIPS/eip-7821
+
 {
 //- Reference account implementation
 }


### PR DESCRIPTION
Adds Uniswap Wallet and Rainbow to the wallets section of the ecosystem listing. Both wallets now support EIP-7702 delegation via their respective Calibur contracts.

Calibur also uniquely supports the ERC-7821 Execute interface for direct batch call execution